### PR TITLE
Use invariant culture when formatting generated values

### DIFF
--- a/src/SwaggerGen/CodeGeneration/CodeGenerator.cs
+++ b/src/SwaggerGen/CodeGeneration/CodeGenerator.cs
@@ -187,7 +187,7 @@ public class CodeGenerator
     {
         if (propertySchema.Enum == null || propertySchema.Enum.Count == 0) return;
 
-        var propertyType = propertySchema.Type?.ToLower();
+        var propertyType = propertySchema.Type?.ToLowerInvariant();
         
         if (propertyType == "integer")
         {
@@ -200,11 +200,17 @@ public class CodeGenerator
                     EnumName = enumName,
                     Namespace = targetNamespace,
                     Description = $"Enum values for {schemaName}.{propertyName}",
-                    Values = propertySchema.Enum.Select((value, index) => new EnumValueInfo
+                    Values = propertySchema.Enum.Select((value, index) =>
                     {
-                        Name = GenerateEnumValueName(value),
-                        Value = value,
-                        Description = $"Value: {value}"
+                        var invariantValue = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+                        return new EnumValueInfo
+                        {
+                            Name = GenerateEnumValueName(value),
+                            Value = value,
+                            ValueLiteral = invariantValue,
+                            Description = $"Value: {invariantValue}"
+                        };
                     }).ToList()
                 };
                 enumInfos.Add(enumName, enumInfo);
@@ -221,11 +227,16 @@ public class CodeGenerator
                     ClassName = className,
                     Namespace = targetNamespace,
                     Description = $"Constants for {schemaName}.{propertyName}",
-                    Constants = propertySchema.Enum.Select(value => new ConstantInfo
+                    Constants = propertySchema.Enum.Select(value =>
                     {
-                        Name = GenerateConstantName(value.ToString() ?? ""),
-                        Value =   Convert.ToString(value, CultureInfo.InvariantCulture) ?? "",
-                        Description = $"Value: {value}"
+                        var invariantValue = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+                        return new ConstantInfo
+                        {
+                            Name = GenerateConstantName(invariantValue),
+                            Value = invariantValue,
+                            Description = $"Value: {invariantValue}"
+                        };
                     }).ToList()
                 };
                 constantsInfos.Add(className, constantsInfo);
@@ -235,7 +246,7 @@ public class CodeGenerator
 
     private string GenerateEnumValueName(object value)
     {
-        var stringValue = value.ToString() ?? "";
+        var stringValue = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
         
         // Convert to PascalCase and ensure it's a valid C# identifier
         var name = ToPascalCase(stringValue);
@@ -255,7 +266,7 @@ public class CodeGenerator
     private string GenerateConstantName(string value)
     {
         // Convert to UPPER_CASE format for constants
-        var name = value.Replace("-", "_").Replace(" ", "_").ToUpper();
+        var name = value.Replace("-", "_").Replace(" ", "_").ToUpperInvariant();
         
         // Ensure it starts with a letter or underscore
         if (name.Length > 0 && char.IsDigit(name[0]))
@@ -490,7 +501,7 @@ public class CodeGenerator
         var typeOverridden = !string.IsNullOrEmpty(rule?.Type);
         if (!typeOverridden && schema.Enum != null && schema.Enum.Count > 0)
         {
-            var propertyType = schema.Type?.ToLower();
+            var propertyType = schema.Type?.ToLowerInvariant();
             
             if (propertyType == "integer")
             {
@@ -563,21 +574,25 @@ public class CodeGenerator
         // String length validation
         if (effectiveMinLength.HasValue)
         {
-            rules.Add(new ValidationRule 
-            { 
-                Rule = "MinimumLength", 
-                Parameters = [effectiveMinLength.Value.ToString()],
-                Message = customMessage ?? $"Must be at least {effectiveMinLength.Value} characters long"
+            var invariantMinLength = Convert.ToString(effectiveMinLength.Value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+            rules.Add(new ValidationRule
+            {
+                Rule = "MinimumLength",
+                Parameters = [invariantMinLength],
+                Message = customMessage ?? $"Must be at least {invariantMinLength} characters long"
             });
         }
 
         if (effectiveMaxLength.HasValue)
         {
-            rules.Add(new ValidationRule 
-            { 
-                Rule = "MaximumLength", 
-                Parameters = [effectiveMaxLength.Value.ToString()],
-                Message = customMessage ?? $"Must be no more than {effectiveMaxLength.Value} characters long"
+            var invariantMaxLength = Convert.ToString(effectiveMaxLength.Value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+            rules.Add(new ValidationRule
+            {
+                Rule = "MaximumLength",
+                Parameters = [invariantMaxLength],
+                Message = customMessage ?? $"Must be no more than {invariantMaxLength} characters long"
             });
         }
 
@@ -595,21 +610,25 @@ public class CodeGenerator
         // Numeric range validation
         if (effectiveMinimum.HasValue)
         {
-            rules.Add(new ValidationRule 
-            { 
-                Rule = "GreaterThanOrEqualTo", 
-                Parameters = [effectiveMinimum.Value.ToString()],
-                Message = customMessage ?? $"Must be greater than or equal to {effectiveMinimum.Value}"
+            var invariantMinimum = Convert.ToString(effectiveMinimum.Value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+            rules.Add(new ValidationRule
+            {
+                Rule = "GreaterThanOrEqualTo",
+                Parameters = [invariantMinimum],
+                Message = customMessage ?? $"Must be greater than or equal to {invariantMinimum}"
             });
         }
 
         if (effectiveMaximum.HasValue)
         {
-            rules.Add(new ValidationRule 
-            { 
-                Rule = "LessThanOrEqualTo", 
-                Parameters = [effectiveMaximum.Value.ToString()],
-                Message = customMessage ?? $"Must be less than or equal to {effectiveMaximum.Value}"
+            var invariantMaximum = Convert.ToString(effectiveMaximum.Value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+            rules.Add(new ValidationRule
+            {
+                Rule = "LessThanOrEqualTo",
+                Parameters = [invariantMaximum],
+                Message = customMessage ?? $"Must be less than or equal to {invariantMaximum}"
             });
         }
 
@@ -689,11 +708,13 @@ public class CodeGenerator
         // Number validation constraints
         if (schema.MultipleOf.HasValue)
         {
-            rules.Add(new ValidationRule 
-            { 
-                Rule = "Must", 
-                Parameters = [$"x => x % {schema.MultipleOf.Value} == 0"],
-                Message = customMessage ?? $"Must be a multiple of {schema.MultipleOf.Value}"
+            var invariantMultipleOf = Convert.ToString(schema.MultipleOf.Value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+            rules.Add(new ValidationRule
+            {
+                Rule = "Must",
+                Parameters = [$"x => x % {invariantMultipleOf} == 0"],
+                Message = customMessage ?? $"Must be a multiple of {invariantMultipleOf}"
             });
         }
 
@@ -713,7 +734,11 @@ public class CodeGenerator
             else if (!string.IsNullOrEmpty(constantsClassName))
             {
                 // For string enums with constants class, use direct string values for backward compatibility
-                var enumValues = string.Join(", ", schema.Enum.Select(e => $"\"{e}\""));
+                var enumValues = string.Join(", ", schema.Enum.Select(e =>
+                {
+                    var invariant = Convert.ToString(e, CultureInfo.InvariantCulture) ?? string.Empty;
+                    return $"\"{invariant}\"";
+                }));
                 rules.Add(new ValidationRule 
                 {
                     Rule = "Must", 
@@ -724,11 +749,15 @@ public class CodeGenerator
             else
             {
                 // Fallback to original validation for backward compatibility
-                var enumValues = string.Join(", ", schema.Enum.Select(e => $"\"{e}\""));
-                rules.Add(new ValidationRule 
-                { 
-                    Rule = "Must", 
-                    Parameters = [$"x => new[] {{ {enumValues} }}.Contains(x.ToString())"],
+                var enumValues = string.Join(", ", schema.Enum.Select(e =>
+                {
+                    var invariant = Convert.ToString(e, CultureInfo.InvariantCulture) ?? string.Empty;
+                    return $"\"{invariant}\"";
+                }));
+                rules.Add(new ValidationRule
+                {
+                    Rule = "Must",
+                    Parameters = [$"x => new[] {{ {enumValues} }}.Contains(System.Convert.ToString(x, System.Globalization.CultureInfo.InvariantCulture))"],
                     Message = customMessage ?? $"Must be one of: {enumValues}"
                 });
             }
@@ -753,7 +782,7 @@ public class CodeGenerator
         }
 
         // Handle cases where Type might be null or empty
-        var schemaType = schema.Type?.ToLower() ?? "object";
+        var schemaType = schema.Type?.ToLowerInvariant() ?? "object";
         
         return schemaType switch
         {
@@ -781,7 +810,7 @@ public class CodeGenerator
         if (words.Length == 1)
         {
             // Single word - just capitalize first letter
-            return char.ToUpper(input[0]) + input.Substring(1);
+            return char.ToUpperInvariant(input[0]) + input.Substring(1);
         }
 
         var result = new StringBuilder();
@@ -789,9 +818,9 @@ public class CodeGenerator
         {
             if (word.Length > 0)
             {
-                result.Append(char.ToUpper(word[0]));
+                result.Append(char.ToUpperInvariant(word[0]));
                 if (word.Length > 1)
-                    result.Append(word.Substring(1).ToLower());
+                    result.Append(word.Substring(1).ToLowerInvariant());
             }
         }
 
@@ -800,11 +829,13 @@ public class CodeGenerator
 
     private string FormatDefaultValue(object value, string type)
     {
-        return type.ToLower() switch
+        var invariantValue = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+        return type.ToLowerInvariant() switch
         {
-            "string" => $"\"{value}\"",
-            "bool" => value.ToString()?.ToLower() ?? "false",
-            _ => value.ToString() ?? ""
+            "string" => $"\"{invariantValue}\"",
+            "bool" => string.IsNullOrEmpty(invariantValue) ? "false" : invariantValue.ToLowerInvariant(),
+            _ => invariantValue
         };
     }
 

--- a/src/SwaggerGen/CodeGeneration/EnumInfo.cs
+++ b/src/SwaggerGen/CodeGeneration/EnumInfo.cs
@@ -18,6 +18,7 @@ public class EnumValueInfo
 {
     public string Name { get; set; } = string.Empty;
     public object Value { get; set; } = 0;
+    public string ValueLiteral { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
 }
 

--- a/src/SwaggerGen/Templates/Enum.hbs
+++ b/src/SwaggerGen/Templates/Enum.hbs
@@ -9,7 +9,7 @@ public enum {{EnumName}}
     /// <summary>
     /// {{Description}}
     /// </summary>
-    {{Name}} = {{Value}}{{#unless @last}},{{/unless}}
+    {{Name}} = {{ValueLiteral}}{{#unless @last}},{{/unless}}
 
 {{/each}}
 }


### PR DESCRIPTION
## Summary
- format enum values, constant literals, validation parameters, and default values with Convert.ToString(..., CultureInfo.InvariantCulture)
- keep enum metadata values typed as object while exposing a ValueLiteral string for templates
- update the enum template to emit ValueLiteral so generated code always uses invariant numeric formatting

## Testing
- dotnet test *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d13a52ff048328a426fa4b4f60d02d