### PR TITLE
Document codebase context hierarchy for AI navigation

### DIFF
--- a/.copilot/context.md
+++ b/.copilot/context.md
@@ -1,0 +1,3 @@
+# Copilot Configuration
+
+Holds GitHub Copilot instructions (`instructions.md`). Useful if adapting editor-integrated suggestions to respect repository patterns described in [../context.md](../context.md).

--- a/.github/context.md
+++ b/.github/context.md
@@ -1,0 +1,3 @@
+# GitHub Configuration
+
+Automation and community settings for the repository. See [workflows](workflows/context.md) for CI/CD pipelines that safeguard the generator similar to how Durable Functions rely on deployment slots and monitoring to maintain orchestrations.

--- a/.github/workflows/context.md
+++ b/.github/workflows/context.md
@@ -1,0 +1,7 @@
+# Workflow Pipelines
+
+GitHub Actions automation ensuring build and release quality:
+- `ci.yml` — Restores, builds, and tests on pushes/PRs against `main` and `develop`. Acts like Durable Functions' integration tests in CI before orchestrations deploy.
+- `publish.yml` — Triggered on version tags or release publication; rebuilds, tests, packs the NuGet tool, and pushes to nuget.org using `NUGET_API_KEY`.
+
+These workflows depend on `dotnet 8.0.x` runners and enforce the contract validated by [../../tests/Asynkron.Jsome.Tests](../../tests/Asynkron.Jsome.Tests/context.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Guidance
+
+- Review the nearest `context.md` files before working in any directory. They serve as an AI-oriented index of the codebase and summarize relationships between subsystems.
+- When modifying files, update the corresponding `context.md` (in the same directory and any relevant parents) to reflect behavioral or structural changes.
+- Preserve the Durable Functions analogies present in `context.md` documents when explaining new features or differences.

--- a/context.md
+++ b/context.md
@@ -1,0 +1,17 @@
+# Repository Overview
+
+Asynkron.Jsome is a .NET 8 global tool that converts Swagger 2.0 and JSON Schema documents into C# DTOs, validators, enums, and optional Protocol Buffer definitions. The CLI flow mirrors Azure Durable Functions' declarative orchestrations in that complex behavior is described up front (via OpenAPI or schema files) and then expanded into executable artifacts, but unlike Durable Functions the output here is static code rather than orchestrated runtime workflows.
+
+## Key Capabilities
+- Command-line entry point in [src/Asynkron.Jsome/Program.cs](src/Asynkron.Jsome/Program.cs) builds a `generate` pipeline around `CodeGenerator`, configuration loading, and schema parsing.
+- Parsing libraries in [src/Asynkron.Jsome/SwaggerParser.cs](src/Asynkron.Jsome/SwaggerParser.cs) and [src/Asynkron.Jsome/JsonSchemaParser.cs](src/Asynkron.Jsome/JsonSchemaParser.cs) normalize Swagger 2.0 or JSON Schema directories into shared `SwaggerDocument` models.
+- Code emission uses Handlebars templates in [src/Asynkron.Jsome/Templates](src/Asynkron.Jsome/Templates/context.md) and runtime options defined under [src/Asynkron.Jsome/CodeGeneration](src/Asynkron.Jsome/CodeGeneration/context.md).
+- Customization mirrors Durable Functions' extensibility patterns via modifier rules and schema validation defined in [src/Asynkron.Jsome/Configuration](src/Asynkron.Jsome/Configuration/context.md).
+- Extensive verification lives in [tests/Asynkron.Jsome.Tests](tests/Asynkron.Jsome.Tests/context.md), ensuring generated code compiles, adheres to configuration, and covers integrations such as OCPP v1.6 schemas.
+
+## Support Assets
+- Sample schemas and configuration examples reside under [schemas](schemas/context.md), [testdata](testdata/context.md), and [src/Asynkron.Jsome/Samples](src/Asynkron.Jsome/Samples/context.md).
+- Automation pipelines are tracked in [.github/workflows](.github/workflows/context.md).
+- Refer to [src/context.md](src/context.md) for a deeper breakdown of the production code tree.
+
+When editing any part of the repository, update the nearest `context.md` to keep this AI-facing index synchronized, similar to how Durable Function orchestration definitions must stay in sync with their activities.

--- a/schemas/context.md
+++ b/schemas/context.md
@@ -1,0 +1,8 @@
+# Schema Catalog
+
+Reference JSON schemas used to validate generator behavior and provide ready-made inputs for integration scenarios.
+
+- [`guidewire`](guidewire/context.md) — Claims management schema sample.
+- [`ocppv16`](ocppv16/context.md) — Open Charge Point Protocol v1.6 message schemas (dozens of request/response pairs).
+
+These directories allow AI agents to reason about real-world payloads similarly to how Azure Durable Functions samples illustrate orchestrations across external services.

--- a/schemas/guidewire/context.md
+++ b/schemas/guidewire/context.md
@@ -1,0 +1,5 @@
+# Guidewire Schemas
+
+Contains `claims.json`, a representative Guidewire InsuranceSuite schema. Use it to exercise nested object graphs, enums, and validation scenarios. The structure stresses the generator's ability to handle deep property paths in `ModifierConfiguration`, similar to orchestrating complex entity graphs in Azure Durable Functions.
+
+Consult [../context.md](../context.md) for links to other schema families.

--- a/schemas/ocppv16/context.md
+++ b/schemas/ocppv16/context.md
@@ -1,0 +1,7 @@
+# OCPP v1.6 Schemas
+
+Wrapper for the Open Charge Point Protocol message definitions. These files feed integration tests that verify the generator can handle a large schema corpus.
+
+- [`json_schemas`](json_schemas/context.md) — Individual request/response schema files (Authorize, BootNotification, etc.).
+
+Like Durable Functions orchestrating IoT command flows, these schemas model bidirectional charger interactions, giving the generator realistic validation paths.

--- a/schemas/ocppv16/json_schemas/context.md
+++ b/schemas/ocppv16/json_schemas/context.md
@@ -1,0 +1,7 @@
+# OCPP v1.6 JSON Schemas
+
+Collection of per-message schema files mirroring the Open Charge Point Protocol 1.6 specification. Filenames follow the `<Action>[Response].json` pattern. Use them to:
+- Stress-test `JsonSchemaParser.ParseDirectory` with dozens of definitions and `$ref` links.
+- Validate enum generation, array constraints, and nested structures under real-world load.
+
+Integration tests in [../../../tests/Asynkron.Jsome.Tests/OcppV16IntegrationTests.cs](../../../tests/Asynkron.Jsome.Tests/context.md#ocpp-v16-tests) rely on this directory. The experience parallels Durable Functions fan-out/fan-in orchestrations over a large set of activities, except here the workload is schema ingestion.

--- a/src/Asynkron.Jsome/CodeGeneration/context.md
+++ b/src/Asynkron.Jsome/CodeGeneration/context.md
@@ -1,0 +1,15 @@
+# Code Generation Layer
+
+This folder contains the transformation pipeline that converts `SwaggerDocument` models into strongly-typed output using Handlebars templates. Think of it as the "activity function" layer compared to Azure Durable Functions—the orchestrator (`Program.cs`) supplies the input, these classes perform the heavy lifting, and templates act like Durable output bindings.
+
+## Key Types
+- `CodeGenerator` — Loads templates, registers helper functions, enforces template availability, and materializes DTOs, validators, enums, constants, and optional Protocol Buffer artifacts according to `CodeGenerationOptions`.
+- `CodeGenerationOptions` — Feature toggles for enum generation, modern C# (nullable + `required` keyword), System.Text.Json, Swashbuckle annotations, record types, proto files, and custom template selection.
+- `CodeGenerationResult` / `GeneratedFile` — Data holders for generated source; results aggregate per-entity artifacts while `GeneratedFile` tracks extension metadata extracted from template frontmatter.
+- `ClassInfo`, `PropertyInfo`, `EnumInfo`, `ConstantsInfo` — Template-ready view models capturing schema descriptions, validation metadata, enum values, and optional references to dedicated enum/constant types.
+
+## Supporting Concepts
+- `TemplateMetadata` reads optional YAML-style frontmatter from `.hbs` files, similar to how Durable Functions use trigger metadata to customize behavior.
+- Validation rule constructs mirror FluentValidation DSL calls so templates can enumerate them consistently.
+
+Refer to [../Templates/context.md](../Templates/context.md) for the default templates that consume these models and [../Configuration/context.md](../Configuration/context.md) for the rule system that influences property shaping.

--- a/src/Asynkron.Jsome/Configuration/context.md
+++ b/src/Asynkron.Jsome/Configuration/context.md
@@ -1,0 +1,11 @@
+# Generation Configuration
+
+Configuration files let consumers reshape generated types without editing schemas. The pattern parallels Azure Durable Functions' binding metadata—external configuration alters execution while the core orchestrator remains untouched.
+
+## Components
+- `ModifierConfiguration` — Strongly typed representation of configuration files (`global` toggles, per-property `rules`, enum handling, etc.).
+- `PropertyRule` — Describes overrides for individual property paths (inclusion, renaming, validation hints) similar to Durable Function retry or timeout policies.
+- `ConfigurationLoader` — Loads YAML or JSON modifier files asynchronously or synchronously; auto-detects format, handles serialization errors, and can persist configurations.
+- `SchemaValidator` — Validates that modifier paths exist in the merged `SwaggerDocument`, surfaces Spectre.Console feedback, and prevents misaligned rule application.
+
+These classes collaborate with [../CodeGeneration](../CodeGeneration/context.md) to adjust `PropertyInfo` metadata before template rendering. Tests covering configuration behaviors live in [../../../tests/Asynkron.Jsome.Tests/ConfigurationTests.cs](../../../tests/Asynkron.Jsome.Tests/context.md#configuration--modifier-tests).

--- a/src/Asynkron.Jsome/Models/context.md
+++ b/src/Asynkron.Jsome/Models/context.md
@@ -1,0 +1,11 @@
+# Swagger Domain Models
+
+`Models` defines the in-memory structures that both parsers and generators operate on. They provide a simplified Swagger 2.0 object graph (info, paths, parameters, schemas) analogous to Durable Functions' durable entity state—centralized objects that capture contract definitions for later execution.
+
+## Highlights
+- `SwaggerDocument` — Root aggregate containing metadata (`Info`), host/base path, schema `Definitions`, and `Paths` operations.
+- `Schema` — Represents schema nodes, tracks type information, validation constraints, `$ref` references, enum values, array/object metadata, and vendor extensions.
+- `PathItem`, `Parameter`, `Response` — Minimal structures for endpoint data (used primarily when generating validator context or future expansions).
+- `Info` — Title/version/description container used for output metadata.
+
+These models are populated by [../SwaggerParser.cs](../SwaggerParser.cs) and [../JsonSchemaParser.cs](../JsonSchemaParser.cs), then consumed by [../CodeGeneration](../CodeGeneration/context.md) to derive template view models.

--- a/src/Asynkron.Jsome/Samples/Configuration/context.md
+++ b/src/Asynkron.Jsome/Samples/Configuration/context.md
@@ -1,0 +1,6 @@
+# Sample Modifier Configurations
+
+Reference modifier files illustrating the configuration surface:
+- `config.json` / `config.yaml` (if present) demonstrate property inclusion/exclusion, namespace overrides, validation constraints, and enum toggles consumed by `ConfigurationLoader`.
+
+Treat these files like Durable Functions local.settings.json templates—they provide a starting point for customizing generator behavior when onboarding a new schema set.

--- a/src/Asynkron.Jsome/Samples/context.md
+++ b/src/Asynkron.Jsome/Samples/context.md
@@ -1,0 +1,7 @@
+# Samples
+
+Quick-start assets demonstrating generator usage:
+- `petstore-swagger.json` — Canonical Swagger 2.0 example for smoke testing the generator pipeline.
+- [`Configuration`](Configuration/context.md) — YAML/JSON snippets showcasing modifier options (global namespace overrides, inclusion filters, validation hints).
+
+These samples function like Durable Functions quickstarts: ready-to-run inputs you can feed into the orchestrator (`Program.cs`) to understand behavior before applying it to production schemas.

--- a/src/Asynkron.Jsome/Templates/context.md
+++ b/src/Asynkron.Jsome/Templates/context.md
@@ -1,0 +1,13 @@
+# Handlebars Templates
+
+These templates define the textual output for the generator. Each file may start with optional frontmatter consumed by `TemplateMetadata` to determine extensions (e.g., `.proto`).
+
+## Default Outputs
+- `DTO.hbs`, `DTORecord.hbs` — Generate C# classes or records with configurable validation attributes, System.Text.Json or Newtonsoft.Json annotations, and optional Swashbuckle metadata.
+- `Validator.hbs` — FluentValidation validator classes aligned with property rules.
+- `Enum.hbs` — Enum definitions for integer-backed enums.
+- `Constants.hbs` — Static classes exposing string enum choices.
+- `proto.hbs`, `proto.enum.hbs`, `proto.string_enum.hbs` — Optional Protocol Buffer message/enum renderers.
+- `FSharp.hbs`, `FSharpModule.hbs`, `TypeScript.hbs` — Ancillary templates for alternate target languages.
+
+Templates act like Durable Functions output bindings: they express the shape of generated artifacts while `CodeGenerator` injects runtime metadata from `ClassInfo`/`PropertyInfo` view models.

--- a/src/Asynkron.Jsome/context.md
+++ b/src/Asynkron.Jsome/context.md
@@ -1,0 +1,20 @@
+# `Asynkron.Jsome` Project
+
+This project compiles into the `dotnet-jsome` global tool. The code orchestrates schema ingestion, configuration, and template-driven code emission in a way reminiscent of Azure Durable Functions orchestrations—`Program.cs` dispatches work across modular components—but the execution is single-run and stateless rather than long-lived workflows.
+
+## Entry Points
+- `Program.cs` wires up `System.CommandLine` commands, Spectre.Console prompts, and dispatches to parsers and generators. It enforces mutual exclusivity between Swagger inputs and schema directories, validates modifier configuration, and invokes code generation.
+- `SwaggerParser.cs` and `JsonSchemaParser.cs` convert raw Swagger 2.0 JSON or JSON Schema directories into `SwaggerDocument` models while resolving `$ref` dependencies and detecting conflicting definitions.
+
+## Domain Models
+- [`Models`](Models/context.md) defines the in-memory Swagger 2.0 representation consumed by generation.
+- [`Configuration`](Configuration/context.md) supplies modifier rules, validation logic, and helpers that function similarly to Durable Functions' bindings—augmenting generation without modifying the core orchestrator.
+
+## Generation Pipeline
+- [`CodeGeneration`](CodeGeneration/context.md) contains classes that transform models into template-ready metadata and produce `GeneratedFile` instances.
+- [`Templates`](Templates/context.md) exposes the Handlebars templates used by the generator; see the folder context for format details.
+
+## Samples and Assets
+- [`Samples`](Samples/context.md) offers example inputs and configuration seeds for quick testing.
+
+Tests validating these behaviors live under [../../tests/Asynkron.Jsome.Tests](../../tests/Asynkron.Jsome.Tests/context.md), providing durable-like regression guarantees.

--- a/src/context.md
+++ b/src/context.md
@@ -1,0 +1,7 @@
+# Source Tree Overview
+
+This directory contains the production code for the `Asynkron.Jsome` .NET tool. The layout intentionally mirrors the major phases of the generation pipeline:
+
+- [`Asynkron.Jsome`](Asynkron.Jsome/context.md) — CLI host, parsers, and all generation logic.
+
+While Azure Durable Functions organizes work into orchestrations, activity functions, and bindings, this source tree separates concerns into parsing, configuration, and templated emission. Each subdirectory's `context.md` explains how those responsibilities map onto Durable-like concepts (e.g., modifier rules behaving like orchestrator policies).

--- a/testdata/context.md
+++ b/testdata/context.md
@@ -1,0 +1,6 @@
+# Test Data
+
+Holds large or external sample inputs used during tests and demos.
+- `stripe-swagger.json` — Realistic Swagger 2.0 spec for validating parser resilience and generation performance.
+
+Treat these artifacts like Durable Functions emulator payloads—feed them into the generator to observe behavior without touching production definitions.

--- a/tests/Asynkron.Jsome.Tests/context.md
+++ b/tests/Asynkron.Jsome.Tests/context.md
@@ -1,0 +1,14 @@
+# Asynkron.Jsome Test Project
+
+xUnit project validating parser correctness, configuration handling, template rendering, and language feature toggles. The structure resembles Azure Durable Functions' multi-phase testing: unit-level checks for orchestrator logic, integration tests for external definitions, and compilation validation to ensure generated code executes.
+
+## Test Categories
+- **Code Generation Basics** (`CodeGenerationTests`, `CompilationValidationTests`) — Ensure DTOs/validators compile, required attributes appear, and generated code is syntactically valid.
+- **Configuration & Modifier Tests** (`ConfigurationTests`, `ModifierConfigurationIntegrationTests`, `SchemaValidatorTests`) — Verify `ModifierConfiguration` loading, rule application, and schema path validation. Mirrors Durable Function binding configuration tests.
+- **Template Extensibility** (`CustomTemplateTests`, `ProtoTemplateTests`, `SystemTextJsonTests`) — Guard template selection, proto output, and System.Text.Json enhancements.
+- **Modern C# Features** (`ModernCSharpFeaturesTests`) — Confirm nullable references, `required` keyword, and record generation toggles.
+- **Parser Validation** (`SwaggerParserTests`, `JsonSchemaParserTests`) — Validate error handling and parsing semantics for Swagger documents and JSON Schema directories.
+- **Domain-Specific Integrations** (`OcppV16ComplianceTests`, `OcppV16IntegrationTests`) — Exercise large schema sets from [../../schemas/ocppv16](../../schemas/ocppv16/context.md) to mimic Durable fan-out workloads over many definitions.
+- **Localization / Regression** (`LocaleIssueTest`) — Prevent culture-specific parsing regressions.
+
+Global usings live in `GlobalUsings.cs`, and the project is defined by `Asynkron.Jsome.Tests.csproj`.

--- a/tests/context.md
+++ b/tests/context.md
@@ -1,0 +1,5 @@
+# Test Suite Overview
+
+The `tests` folder contains xUnit-based automated coverage for the generator. All projects target .NET 8 and mirror Azure Durable Functions' emphasis on regression safety—each suite verifies that declarative definitions expand into the expected runtime behavior.
+
+- [`Asynkron.Jsome.Tests`](Asynkron.Jsome.Tests/context.md) — Main unit/integration test project.


### PR DESCRIPTION
## Summary
- add `context.md` documentation to every project directory to describe responsibilities and Durable Functions parallels
- create a root AGENTS.md reminding contributors to consult and maintain the new context index

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da10ded6b0832892ecf06d64484fda