### PR TITLE
Document context index across repository

### DIFF
--- a/.github/context.md
+++ b/.github/context.md
@@ -1,3 +1,5 @@
 # GitHub Configuration
 
-Automation and community settings for the repository. See [workflows](workflows/context.md) for CI/CD pipelines that safeguard the generator similar to how Durable Functions rely on deployment slots and monitoring to maintain orchestrations.
+Automation and community settings for the repository. See [workflows](workflows/context.md) for CI/CD pipelines that safeguard
+the generator similar to how Durable Functions rely on deployment slots and monitoring to maintain orchestrations. Issue templates
+and other metadata live alongside these workflows to guide contributions.

--- a/.github/context.md
+++ b/.github/context.md
@@ -1,5 +1,5 @@
 # GitHub Configuration
 
 Automation and community settings for the repository. See [workflows](workflows/context.md) for CI/CD pipelines that safeguard
-the generator similar to how Durable Functions rely on deployment slots and monitoring to maintain orchestrations. Issue templates
+the generator by restoring packages, building, testing, and publishing artifacts. Issue templates
 and other metadata live alongside these workflows to guide contributions.

--- a/.github/workflows/context.md
+++ b/.github/workflows/context.md
@@ -1,7 +1,7 @@
 # Workflow Pipelines
 
 GitHub Actions automation ensuring build and release quality:
-- `ci.yml` — Restores, builds, and tests on pushes/PRs against `main` and `develop`. Acts like Durable Functions' integration tests in CI before orchestrations deploy.
+- `ci.yml` — Restores, builds, and tests on pushes/PRs against `main` and `develop`. Serves as the continuous verification gate before releases.
 - `publish.yml` — Triggered on version tags or release publication; rebuilds, tests, packs the NuGet tool, and pushes to nuget.org using `NUGET_API_KEY`.
 
 These workflows depend on `dotnet 8.0.x` runners and enforce the contract validated by [../../tests/Asynkron.Jsome.Tests](../../tests/Asynkron.Jsome.Tests/context.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Agent Guidance
-
-- Review the nearest `context.md` files before working in any directory. They serve as an AI-oriented index of the codebase and summarize relationships between subsystems.
-- When modifying files, update the corresponding `context.md` (in the same directory and any relevant parents) to reflect behavioral or structural changes.
-- Preserve the Durable Functions analogies present in `context.md` documents when explaining new features or differences.
+- Always open the nearest `context.md` before working in a directory. Every folder in the repo has one and together they form an
+  AI-oriented index of the codebase and the relationships between subsystems.
+- When you modify or add files, update the corresponding `context.md` in that directory (and any parents whose summaries change)
+  so the index stays trustworthy.
+- Preserve the Durable Functions analogies present in `context.md` documents when explaining new features or differences; extend
+  them when helpful to clarify behavior changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,5 +3,5 @@
   AI-oriented index of the codebase and the relationships between subsystems.
 - When you modify or add files, update the corresponding `context.md` in that directory (and any parents whose summaries change)
   so the index stays trustworthy.
-- Preserve the Durable Functions analogies present in `context.md` documents when explaining new features or differences; extend
-  them when helpful to clarify behavior changes.
+- Keep the `context.md` files accurate and concise—update descriptions and cross-links whenever functionality changes so future
+  agents can trust the index.

--- a/context.md
+++ b/context.md
@@ -1,8 +1,8 @@
 # Repository Overview
 
 Asynkron.Jsome ships as a .NET 8 global tool (`dotnet-jsome`) that ingests Swagger 2.0 or loose JSON Schema files and emits
-C#/Proto code via Handlebars templates. Think of the repo as a Durable Functions app in miniature: the CLI orchestrator lives in
-`src`, configuration/inputs mimic bindings, and the tests/automation guarantee each orchestration run stays deterministic.
+C#/Proto code via Handlebars templates. The repository is organized around that pipeline: the CLI host lives in `src`, supporting
+inputs sit beside it, and the tests/automation keep the entire flow deterministic.
 
 ## Top-Level Map
 - [`src`](src/context.md) — Production code. `Asynkron.Jsome` is the sole project and contains the CLI host, parsers, code
@@ -22,7 +22,7 @@ C#/Proto code via Handlebars templates. Think of the repo as a Durable Functions
 
 ## Quick Entry Points
 - Start at [`src/Asynkron.Jsome/Program.cs`](src/Asynkron.Jsome/context.md#entry-points) for CLI wiring and option handling.
-- Follow the Durable-like flow through the parser layers
+- Follow the end-to-end flow through the parser layers
   ([`SwaggerParser`](src/Asynkron.Jsome/context.md#entry-points),
   [`JsonSchemaParser`](src/Asynkron.Jsome/context.md#entry-points)), configuration modifiers
   ([`Configuration`](src/Asynkron.Jsome/Configuration/context.md)), generation activities

--- a/context.md
+++ b/context.md
@@ -1,15 +1,35 @@
 # Repository Overview
 
-Asynkron.Jsome is a .NET 8 global tool that converts Swagger 2.0 and JSON Schema documents into C# DTOs, validators, enums, and optional Protocol Buffer definitions.
+Asynkron.Jsome ships as a .NET 8 global tool (`dotnet-jsome`) that ingests Swagger 2.0 or loose JSON Schema files and emits
+C#/Proto code via Handlebars templates. Think of the repo as a Durable Functions app in miniature: the CLI orchestrator lives in
+`src`, configuration/inputs mimic bindings, and the tests/automation guarantee each orchestration run stays deterministic.
 
-## Key Capabilities
-- Command-line entry point in [src/Asynkron.Jsome/Program.cs](src/Asynkron.Jsome/Program.cs) builds a `generate` pipeline around `CodeGenerator`, configuration loading, and schema parsing.
-- Parsing libraries in [src/Asynkron.Jsome/SwaggerParser.cs](src/Asynkron.Jsome/SwaggerParser.cs) and [src/Asynkron.Jsome/JsonSchemaParser.cs](src/Asynkron.Jsome/JsonSchemaParser.cs) normalize Swagger 2.0 or JSON Schema directories into shared `SwaggerDocument` models.
-- Code emission uses Handlebars templates in [src/Asynkron.Jsome/Templates](src/Asynkron.Jsome/Templates/context.md) and runtime options defined under [src/Asynkron.Jsome/CodeGeneration](src/Asynkron.Jsome/CodeGeneration/context.md).
+## Top-Level Map
+- [`src`](src/context.md) — Production code. `Asynkron.Jsome` is the sole project and contains the CLI host, parsers, code
+  generation pipeline, and templates.
+- [`tests`](tests/context.md) — xUnit suites that compile generated output, validate configuration edge cases, and stress-test the
+  parsers with large schema catalogs.
+- [`schemas`](schemas/context.md) & [`testdata`](testdata/context.md) — Real-world schema corpora consumed by integration tests
+  and demos (OCPP v1.6, Guidewire, Stripe). Use these when you need exhaustive payload coverage.
+- [`src/Asynkron.Jsome/Samples`](src/Asynkron.Jsome/Samples/context.md) — Quick-start inputs plus modifier configuration
+  templates for experimentation.
+- [`generate.sh`](generate.sh) / [`validate-nuget-setup.sh`](validate-nuget-setup.sh) — Convenience scripts for local generation
+  and verifying the tool’s NuGet packaging prerequisites.
+- [`config_demo.cs`](config_demo.cs) and the YAML files at the root illustrate how configuration objects are materialized from the
+  `ModifierConfiguration` model.
+- CI/CD definitions reside under [`.github/workflows`](.github/workflows/context.md); Copilot/editor guidance sits in
+  [`.copilot`](.copilot/context.md).
 
-- Extensive verification lives in [tests/Asynkron.Jsome.Tests](tests/Asynkron.Jsome.Tests/context.md), ensuring generated code compiles, adheres to configuration, and covers integrations such as OCPP v1.6 schemas.
+## Quick Entry Points
+- Start at [`src/Asynkron.Jsome/Program.cs`](src/Asynkron.Jsome/context.md#entry-points) for CLI wiring and option handling.
+- Follow the Durable-like flow through the parser layers
+  ([`SwaggerParser`](src/Asynkron.Jsome/context.md#entry-points),
+  [`JsonSchemaParser`](src/Asynkron.Jsome/context.md#entry-points)), configuration modifiers
+  ([`Configuration`](src/Asynkron.Jsome/Configuration/context.md)), generation activities
+  ([`CodeGeneration`](src/Asynkron.Jsome/CodeGeneration/context.md)), and template bindings
+  ([`Templates`](src/Asynkron.Jsome/Templates/context.md)).
+- For regression expectations, consult [`tests/Asynkron.Jsome.Tests`](tests/Asynkron.Jsome.Tests/context.md) which documents the
+  suite layout and links back to the assets it exercises.
 
-## Support Assets
-- Sample schemas and configuration examples reside under [schemas](schemas/context.md), [testdata](testdata/context.md), and [src/Asynkron.Jsome/Samples](src/Asynkron.Jsome/Samples/context.md).
-- Automation pipelines are tracked in [.github/workflows](.github/workflows/context.md).
-- Refer to [src/context.md](src/context.md) for a deeper breakdown of the production code tree.
+This `context.md` and its descendants form the AI-facing search index—skim them whenever you need to orient yourself before
+reading code.

--- a/schemas/context.md
+++ b/schemas/context.md
@@ -1,8 +1,11 @@
 # Schema Catalog
 
-Reference JSON schemas used to validate generator behavior and provide ready-made inputs for integration scenarios.
+Reference JSON schemas used to validate generator behavior and provide ready-made inputs for integration scenarios. These serve
+as Durable Functions-style external services that the orchestrator must coordinate with.
 
-- [`guidewire`](guidewire/context.md) — Claims management schema sample.
-- [`ocppv16`](ocppv16/context.md) — Open Charge Point Protocol v1.6 message schemas (dozens of request/response pairs).
+- [`guidewire`](guidewire/context.md) — Claims management schema sample with deep object graphs and enum coverage.
+- [`ocppv16`](ocppv16/context.md) — Open Charge Point Protocol v1.6 message schemas (dozens of request/response pairs) consumed
+  heavily by the OCPP tests.
 
-These directories allow AI agents to reason about real-world payloads similarly to how Azure Durable Functions samples illustrate orchestrations across external services.
+Integration tests under [../tests/Asynkron.Jsome.Tests](../tests/Asynkron.Jsome.Tests/context.md#domain-specific-integrations)
+load these directories to ensure the generator handles real-world payload complexity.

--- a/schemas/context.md
+++ b/schemas/context.md
@@ -1,7 +1,7 @@
 # Schema Catalog
 
-Reference JSON schemas used to validate generator behavior and provide ready-made inputs for integration scenarios. These serve
-as Durable Functions-style external services that the orchestrator must coordinate with.
+Reference JSON schemas used to validate generator behavior and provide ready-made inputs for integration scenarios. Treat them as
+external contracts that the CLI must coordinate with during code generation.
 
 - [`guidewire`](guidewire/context.md) — Claims management schema sample with deep object graphs and enum coverage.
 - [`ocppv16`](ocppv16/context.md) — Open Charge Point Protocol v1.6 message schemas (dozens of request/response pairs) consumed

--- a/schemas/guidewire/context.md
+++ b/schemas/guidewire/context.md
@@ -1,5 +1,12 @@
 # Guidewire Schemas
 
-Contains `claims.json`, a representative Guidewire InsuranceSuite schema. Use it to exercise nested object graphs, enums, and validation scenarios. The structure stresses the generator's ability to handle deep property paths in `ModifierConfiguration`, similar to orchestrating complex entity graphs in Azure Durable Functions.
+Contains `claims.json`, a representative Guidewire InsuranceSuite schema. Use it to exercise nested object graphs, enums, and
+validation scenarios. The structure stresses the generator's ability to handle deep property paths in `ModifierConfiguration`,
+similar to orchestrating complex entity graphs in Azure Durable Functions.
+
+Relevant tests:
+- `CodeGenerationTests` and `ModifierConfigurationIntegrationTests`
+  ([../../tests/Asynkron.Jsome.Tests](../../tests/Asynkron.Jsome.Tests/context.md)) reference this schema to validate inclusion
+  rules and enum handling.
 
 Consult [../context.md](../context.md) for links to other schema families.

--- a/schemas/guidewire/context.md
+++ b/schemas/guidewire/context.md
@@ -1,8 +1,7 @@
 # Guidewire Schemas
 
 Contains `claims.json`, a representative Guidewire InsuranceSuite schema. Use it to exercise nested object graphs, enums, and
-validation scenarios. The structure stresses the generator's ability to handle deep property paths in `ModifierConfiguration`,
-similar to orchestrating complex entity graphs in Azure Durable Functions.
+validation scenarios. The structure stresses the generator's ability to handle deep property paths in `ModifierConfiguration`.
 
 Relevant tests:
 - `CodeGenerationTests` and `ModifierConfigurationIntegrationTests`

--- a/schemas/ocppv16/context.md
+++ b/schemas/ocppv16/context.md
@@ -1,7 +1,11 @@
 # OCPP v1.6 Schemas
 
-Wrapper for the Open Charge Point Protocol message definitions. These files feed integration tests that verify the generator can handle a large schema corpus.
+Wrapper for the Open Charge Point Protocol message definitions. These files feed integration tests that verify the generator can
+handle a large schema corpus.
 
 - [`json_schemas`](json_schemas/context.md) — Individual request/response schema files (Authorize, BootNotification, etc.).
 
-Like Durable Functions orchestrating IoT command flows, these schemas model bidirectional charger interactions, giving the generator realistic validation paths.
+Like Durable Functions orchestrating IoT command flows, these schemas model bidirectional charger interactions, giving the
+generator realistic validation paths. See
+[../../tests/Asynkron.Jsome.Tests/context.md#domain-specific-integrations](../../tests/Asynkron.Jsome.Tests/context.md#domain-specific-integrations)
+for the test suites that consume this directory.

--- a/schemas/ocppv16/context.md
+++ b/schemas/ocppv16/context.md
@@ -5,7 +5,6 @@ handle a large schema corpus.
 
 - [`json_schemas`](json_schemas/context.md) — Individual request/response schema files (Authorize, BootNotification, etc.).
 
-Like Durable Functions orchestrating IoT command flows, these schemas model bidirectional charger interactions, giving the
-generator realistic validation paths. See
+These schemas model bidirectional charger interactions, giving the generator realistic validation paths. See
 [../../tests/Asynkron.Jsome.Tests/context.md#domain-specific-integrations](../../tests/Asynkron.Jsome.Tests/context.md#domain-specific-integrations)
 for the test suites that consume this directory.

--- a/schemas/ocppv16/json_schemas/context.md
+++ b/schemas/ocppv16/json_schemas/context.md
@@ -7,5 +7,5 @@ Collection of per-message schema files mirroring the Open Charge Point Protocol 
 
 Integration tests in
 [../../../tests/Asynkron.Jsome.Tests/OcppV16IntegrationTests.cs](../../../tests/Asynkron.Jsome.Tests/context.md#domain-specific-integrations)
-and `OcppV16ComplianceTests` rely on this directory. The experience parallels Durable Functions fan-out/fan-in orchestrations over
-a large set of activities, except here the workload is schema ingestion.
+and `OcppV16ComplianceTests` rely on this directory. Expect fan-out/fan-in style workloads because the generator must ingest a
+large set of related schemas.

--- a/schemas/ocppv16/json_schemas/context.md
+++ b/schemas/ocppv16/json_schemas/context.md
@@ -1,7 +1,11 @@
 # OCPP v1.6 JSON Schemas
 
-Collection of per-message schema files mirroring the Open Charge Point Protocol 1.6 specification. Filenames follow the `<Action>[Response].json` pattern. Use them to:
+Collection of per-message schema files mirroring the Open Charge Point Protocol 1.6 specification. Filenames follow the
+`<Action>[Response].json` pattern. Use them to:
 - Stress-test `JsonSchemaParser.ParseDirectory` with dozens of definitions and `$ref` links.
 - Validate enum generation, array constraints, and nested structures under real-world load.
 
-Integration tests in [../../../tests/Asynkron.Jsome.Tests/OcppV16IntegrationTests.cs](../../../tests/Asynkron.Jsome.Tests/context.md#ocpp-v16-tests) rely on this directory. The experience parallels Durable Functions fan-out/fan-in orchestrations over a large set of activities, except here the workload is schema ingestion.
+Integration tests in
+[../../../tests/Asynkron.Jsome.Tests/OcppV16IntegrationTests.cs](../../../tests/Asynkron.Jsome.Tests/context.md#domain-specific-integrations)
+and `OcppV16ComplianceTests` rely on this directory. The experience parallels Durable Functions fan-out/fan-in orchestrations over
+a large set of activities, except here the workload is schema ingestion.

--- a/src/Asynkron.Jsome/CodeGeneration/context.md
+++ b/src/Asynkron.Jsome/CodeGeneration/context.md
@@ -1,8 +1,8 @@
 # Code Generation Layer
 
 This folder contains the transformation pipeline that converts `SwaggerDocument` models into strongly-typed output using
-Handlebars templates. Think of it as the Durable Functions "activity" stage: the orchestrator (`Program.cs`) supplies the inputs,
-these classes compute the payloads, and the templates act like output bindings that persist the work.
+Handlebars templates. `Program.cs` supplies inputs, these classes compute the payloads, and the templates persist the results to
+disk.
 
 ## Core Components
 - `CodeGenerator` — Loads template files (respecting custom directories or curated template lists), registers helpers, merges in

--- a/src/Asynkron.Jsome/Configuration/context.md
+++ b/src/Asynkron.Jsome/Configuration/context.md
@@ -1,13 +1,13 @@
 # Generation Configuration
 
-Configuration files let consumers reshape generated types without editing schemas. The pattern parallels Azure Durable Functions'
-binding metadata—external configuration alters execution while the core orchestrator remains untouched.
+Configuration files let consumers reshape generated types without editing schemas. External configuration alters execution while
+the core generator remains untouched.
 
 ## Components
 - `ModifierConfiguration` — Strongly typed representation of configuration files (`global` toggles, per-property `rules`, enum
   handling, default include semantics). Provides helpers to fetch rules, inspect inclusion, and enumerate child paths.
 - `PropertyRule` — Describes overrides for individual property paths (inclusion flags, `renameTo`, `enumType`, `jsonPropertyName`,
-  validation hints like `minLength`/`maxLength`). Acts similarly to Durable retry/time-out policies scoped to activities.
+  validation hints like `minLength`/`maxLength`).
 - `ConfigurationLoader` — Loads YAML or JSON modifier files, autodetects format, handles serialization exceptions, and exposes
   asynchronous/synchronous APIs plus a `Save` helper for writing configurations back to disk.
 - `SchemaValidator` — Validates that modifier paths exist in the merged `SwaggerDocument`, surfaces Spectre.Console tables, and

--- a/src/Asynkron.Jsome/Configuration/context.md
+++ b/src/Asynkron.Jsome/Configuration/context.md
@@ -1,11 +1,19 @@
 # Generation Configuration
 
-Configuration files let consumers reshape generated types without editing schemas. The pattern parallels Azure Durable Functions' binding metadata—external configuration alters execution while the core orchestrator remains untouched.
+Configuration files let consumers reshape generated types without editing schemas. The pattern parallels Azure Durable Functions'
+binding metadata—external configuration alters execution while the core orchestrator remains untouched.
 
 ## Components
-- `ModifierConfiguration` — Strongly typed representation of configuration files (`global` toggles, per-property `rules`, enum handling, etc.).
-- `PropertyRule` — Describes overrides for individual property paths (inclusion, renaming, validation hints) similar to Durable Function retry or timeout policies.
-- `ConfigurationLoader` — Loads YAML or JSON modifier files asynchronously or synchronously; auto-detects format, handles serialization errors, and can persist configurations.
-- `SchemaValidator` — Validates that modifier paths exist in the merged `SwaggerDocument`, surfaces Spectre.Console feedback, and prevents misaligned rule application.
+- `ModifierConfiguration` — Strongly typed representation of configuration files (`global` toggles, per-property `rules`, enum
+  handling, default include semantics). Provides helpers to fetch rules, inspect inclusion, and enumerate child paths.
+- `PropertyRule` — Describes overrides for individual property paths (inclusion flags, `renameTo`, `enumType`, `jsonPropertyName`,
+  validation hints like `minLength`/`maxLength`). Acts similarly to Durable retry/time-out policies scoped to activities.
+- `ConfigurationLoader` — Loads YAML or JSON modifier files, autodetects format, handles serialization exceptions, and exposes
+  asynchronous/synchronous APIs plus a `Save` helper for writing configurations back to disk.
+- `SchemaValidator` — Validates that modifier paths exist in the merged `SwaggerDocument`, surfaces Spectre.Console tables, and
+  prevents misaligned rule application before generation.
 
-These classes collaborate with [../CodeGeneration](../CodeGeneration/context.md) to adjust `PropertyInfo` metadata before template rendering. Tests covering configuration behaviors live in [../../../tests/Asynkron.Jsome.Tests/ConfigurationTests.cs](../../../tests/Asynkron.Jsome.Tests/context.md#configuration--modifier-tests).
+These classes collaborate with [../CodeGeneration](../CodeGeneration/context.md) to adjust `PropertyInfo` metadata before template
+rendering. Tests covering configuration behaviors live in
+[../../../tests/Asynkron.Jsome.Tests/ConfigurationTests.cs](../../../tests/Asynkron.Jsome.Tests/context.md#configuration--modifier-tests)
+and related fixtures.

--- a/src/Asynkron.Jsome/Models/context.md
+++ b/src/Asynkron.Jsome/Models/context.md
@@ -1,8 +1,7 @@
 # Swagger Domain Models
 
 `Models` defines the in-memory structures that both parsers and generators operate on. They provide a simplified Swagger 2.0
-object graph (info, paths, parameters, schemas) analogous to Durable Functions' durable entity state—centralized objects that
-capture contract definitions for later execution.
+object graph (info, paths, parameters, schemas) that centralizes contract definitions for later stages of the pipeline.
 
 ## Type Breakdown
 - `SwaggerDocument` — Root aggregate containing metadata (`Info`), host/base path, schemes, `Definitions`, and path items.

--- a/src/Asynkron.Jsome/Models/context.md
+++ b/src/Asynkron.Jsome/Models/context.md
@@ -1,11 +1,18 @@
 # Swagger Domain Models
 
-`Models` defines the in-memory structures that both parsers and generators operate on. They provide a simplified Swagger 2.0 object graph (info, paths, parameters, schemas) analogous to Durable Functions' durable entity state—centralized objects that capture contract definitions for later execution.
+`Models` defines the in-memory structures that both parsers and generators operate on. They provide a simplified Swagger 2.0
+object graph (info, paths, parameters, schemas) analogous to Durable Functions' durable entity state—centralized objects that
+capture contract definitions for later execution.
 
-## Highlights
-- `SwaggerDocument` — Root aggregate containing metadata (`Info`), host/base path, schema `Definitions`, and `Paths` operations.
-- `Schema` — Represents schema nodes, tracks type information, validation constraints, `$ref` references, enum values, array/object metadata, and vendor extensions.
-- `PathItem`, `Parameter`, `Response` — Minimal structures for endpoint data (used primarily when generating validator context or future expansions).
-- `Info` — Title/version/description container used for output metadata.
+## Type Breakdown
+- `SwaggerDocument` — Root aggregate containing metadata (`Info`), host/base path, schemes, `Definitions`, and path items.
+- `Info` — Title/version/description container surfaced by the CLI summaries and persisted into generated headers.
+- `Schema` — Represents schema nodes and validation constraints, including arrays, objects, enums, `$ref`, `allOf`, `additionalProperties`,
+  and vendor extensions. Includes `AdditionalPropertiesConverter` to support boolean/object shapes.
+- `PathItem`, `Parameter`, `Response` — Minimal request/response metadata used primarily by future expansion points and to keep the
+  model faithful to Swagger.
+- `Xml`, `ExternalDocs` (nested within `Schema`) — Carry secondary metadata for XML output and documentation links.
 
-These models are populated by [../SwaggerParser.cs](../SwaggerParser.cs) and [../JsonSchemaParser.cs](../JsonSchemaParser.cs), then consumed by [../CodeGeneration](../CodeGeneration/context.md) to derive template view models.
+These models are populated by [`../SwaggerParser.cs`](../SwaggerParser.cs) and
+[`../JsonSchemaParser.cs`](../JsonSchemaParser.cs), then consumed by the view models in
+[`../CodeGeneration`](../CodeGeneration/context.md).

--- a/src/Asynkron.Jsome/Samples/Configuration/context.md
+++ b/src/Asynkron.Jsome/Samples/Configuration/context.md
@@ -5,5 +5,4 @@ Reference modifier files illustrating the configuration surface:
   validation overrides.
 - `sample-config.json` — JSON equivalent useful when scripting configuration generation.
 
-Treat these files like Durable Functions `local.settings.json` templates—they provide a starting point for customizing generator
-behavior when onboarding a new schema set.
+Use these files as starting points when customizing generator behavior for a new schema set.

--- a/src/Asynkron.Jsome/Samples/Configuration/context.md
+++ b/src/Asynkron.Jsome/Samples/Configuration/context.md
@@ -1,6 +1,9 @@
 # Sample Modifier Configurations
 
 Reference modifier files illustrating the configuration surface:
-- `config.json` / `config.yaml` (if present) demonstrate property inclusion/exclusion, namespace overrides, validation constraints, and enum toggles consumed by `ConfigurationLoader`.
+- `sample-config.yaml` — YAML form of `ModifierConfiguration` demonstrating `global.namespace`, `rules` for inclusion, and
+  validation overrides.
+- `sample-config.json` — JSON equivalent useful when scripting configuration generation.
 
-Treat these files like Durable Functions local.settings.json templates—they provide a starting point for customizing generator behavior when onboarding a new schema set.
+Treat these files like Durable Functions `local.settings.json` templates—they provide a starting point for customizing generator
+behavior when onboarding a new schema set.

--- a/src/Asynkron.Jsome/Samples/context.md
+++ b/src/Asynkron.Jsome/Samples/context.md
@@ -5,5 +5,4 @@ Quick-start assets demonstrating generator usage:
 - [`Configuration`](Configuration/context.md) — YAML/JSON snippets (`sample-config.yaml`, `sample-config.json`) showcasing
   modifier options such as namespace overrides, inclusion filters, and validation hints.
 
-These samples function like Durable Functions quickstarts: ready-to-run inputs you can feed into the orchestrator (`Program.cs`)
-to understand behavior before applying it to production schemas.
+Use these samples to exercise the generator end to end with minimal setup before applying it to production schemas.

--- a/src/Asynkron.Jsome/Samples/context.md
+++ b/src/Asynkron.Jsome/Samples/context.md
@@ -2,6 +2,8 @@
 
 Quick-start assets demonstrating generator usage:
 - `petstore-swagger.json` — Canonical Swagger 2.0 example for smoke testing the generator pipeline.
-- [`Configuration`](Configuration/context.md) — YAML/JSON snippets showcasing modifier options (global namespace overrides, inclusion filters, validation hints).
+- [`Configuration`](Configuration/context.md) — YAML/JSON snippets (`sample-config.yaml`, `sample-config.json`) showcasing
+  modifier options such as namespace overrides, inclusion filters, and validation hints.
 
-These samples function like Durable Functions quickstarts: ready-to-run inputs you can feed into the orchestrator (`Program.cs`) to understand behavior before applying it to production schemas.
+These samples function like Durable Functions quickstarts: ready-to-run inputs you can feed into the orchestrator (`Program.cs`)
+to understand behavior before applying it to production schemas.

--- a/src/Asynkron.Jsome/Templates/context.md
+++ b/src/Asynkron.Jsome/Templates/context.md
@@ -10,4 +10,5 @@ These templates define the textual output for the generator. Each file may start
 - `proto.hbs`, `proto.enum.hbs`, `proto.string_enum.hbs` — Optional Protocol Buffer message/enum renderers.
 - `FSharp.hbs`, `FSharpModule.hbs`, `TypeScript.hbs` — Ancillary templates for alternate target languages.
 
-Templates act like Durable Functions output bindings: they express the shape of generated artifacts while `CodeGenerator` injects runtime metadata from `ClassInfo`/`PropertyInfo` view models.
+Templates express the shape of generated artifacts while `CodeGenerator` injects runtime metadata from `ClassInfo`/`PropertyInfo`
+view models.

--- a/src/Asynkron.Jsome/context.md
+++ b/src/Asynkron.Jsome/context.md
@@ -1,7 +1,7 @@
 # `Asynkron.Jsome` Project
 
-Compiles into the `dotnet-jsome` global tool. The program emulates a Durable Functions orchestration: `Program.cs` collects input,
-invokes parser "activities", validates modifier bindings, and finally calls the code generator that fans out to template writers.
+Compiles into the `dotnet-jsome` global tool. `Program.cs` collects input, invokes parser helpers, validates modifier bindings,
+and finally calls the code generator that dispatches to template writers.
 
 ## Entry Points & CLI Flow
 - `Program.cs`
@@ -10,17 +10,16 @@ invokes parser "activities", validates modifier bindings, and finally calls the 
     summaries with ANSI formatting.
   - Applies feature toggles (modern C#, records, System.Text.Json attributes, Swashbuckle annotations, proto emission, custom
     template selection) through `CodeGenerationOptions` before executing generation.
-  - Provides convenience summaries (`DisplaySwaggerSummary`, `DisplayJsonSchemaSummary`) and confirmation prompts akin to Durable
-    Functions checkpoints before the activity work starts.
+  - Provides convenience summaries (`DisplaySwaggerSummary`, `DisplayJsonSchemaSummary`) and confirmation prompts before
+    generation begins.
 - `Asynkron.Jsome.csproj` (linked from [../context.md](../context.md)) wires in Handlebars.Net, Spectre.Console, FluentValidation,
   and serialization packages used throughout the pipeline.
 
-## Parser Activities
+## Parser Layer
 - `SwaggerParser.cs` — Deserializes Swagger 2.0 JSON, enforces spec-level invariants (version, info fields), and produces
   `SwaggerDocument` aggregates. Offers `GetDocumentSummary` for CLI reporting.
 - `JsonSchemaParser.cs` — Walks a directory of JSON Schema files, merging root schemas and internal `definitions`, deduplicating by
-  semantic equality, and ensuring `$ref` targets exist. Serves the same role as a Durable fan-in activity composing results before
-  orchestration continues.
+  semantic equality, and ensuring `$ref` targets exist so downstream stages receive a coherent catalog.
 
 ## Domain Models & Configuration
 - Models live in [`Models`](Models/context.md) and capture the normalized Swagger object graph consumed downstream.
@@ -38,5 +37,5 @@ invokes parser "activities", validates modifier bindings, and finally calls the 
 - [`Samples`](Samples/context.md) contains ready-to-run Swagger documents and modifier configs for demos.
 - Root-level configuration examples (`config_demo.cs`, YAML/JSON templates) show how to author modifier files programmatically.
 
-Validation and regression coverage reside in [../../tests/Asynkron.Jsome.Tests](../../tests/Asynkron.Jsome.Tests/context.md),
-mirroring Durable Functions' reliance on automated integration tests to protect orchestrator behavior.
+Validation and regression coverage reside in [../../tests/Asynkron.Jsome.Tests](../../tests/Asynkron.Jsome.Tests/context.md), which
+exercise the CLI and generator together to guard against regressions.

--- a/src/Asynkron.Jsome/context.md
+++ b/src/Asynkron.Jsome/context.md
@@ -1,20 +1,42 @@
 # `Asynkron.Jsome` Project
 
-This project compiles into the `dotnet-jsome` global tool. The code orchestrates schema ingestion, configuration, and template-driven code emission in a way reminiscent of Azure Durable Functions orchestrations—`Program.cs` dispatches work across modular components—but the execution is single-run and stateless rather than long-lived workflows.
+Compiles into the `dotnet-jsome` global tool. The program emulates a Durable Functions orchestration: `Program.cs` collects input,
+invokes parser "activities", validates modifier bindings, and finally calls the code generator that fans out to template writers.
 
-## Entry Points
-- `Program.cs` wires up `System.CommandLine` commands, Spectre.Console prompts, and dispatches to parsers and generators. It enforces mutual exclusivity between Swagger inputs and schema directories, validates modifier configuration, and invokes code generation.
-- `SwaggerParser.cs` and `JsonSchemaParser.cs` convert raw Swagger 2.0 JSON or JSON Schema directories into `SwaggerDocument` models while resolving `$ref` dependencies and detecting conflicting definitions.
+## Entry Points & CLI Flow
+- `Program.cs`
+  - Bootstraps System.CommandLine commands (`generate`, `help`) and renders Spectre.Console banners/help text.
+  - Validates mutually exclusive inputs (single Swagger file vs. schema directory), normalizes paths, and surfaces configuration
+    summaries with ANSI formatting.
+  - Applies feature toggles (modern C#, records, System.Text.Json attributes, Swashbuckle annotations, proto emission, custom
+    template selection) through `CodeGenerationOptions` before executing generation.
+  - Provides convenience summaries (`DisplaySwaggerSummary`, `DisplayJsonSchemaSummary`) and confirmation prompts akin to Durable
+    Functions checkpoints before the activity work starts.
+- `Asynkron.Jsome.csproj` (linked from [../context.md](../context.md)) wires in Handlebars.Net, Spectre.Console, FluentValidation,
+  and serialization packages used throughout the pipeline.
 
-## Domain Models
-- [`Models`](Models/context.md) defines the in-memory Swagger 2.0 representation consumed by generation.
-- [`Configuration`](Configuration/context.md) supplies modifier rules, validation logic, and helpers that function similarly to Durable Functions' bindings—augmenting generation without modifying the core orchestrator.
+## Parser Activities
+- `SwaggerParser.cs` — Deserializes Swagger 2.0 JSON, enforces spec-level invariants (version, info fields), and produces
+  `SwaggerDocument` aggregates. Offers `GetDocumentSummary` for CLI reporting.
+- `JsonSchemaParser.cs` — Walks a directory of JSON Schema files, merging root schemas and internal `definitions`, deduplicating by
+  semantic equality, and ensuring `$ref` targets exist. Serves the same role as a Durable fan-in activity composing results before
+  orchestration continues.
+
+## Domain Models & Configuration
+- Models live in [`Models`](Models/context.md) and capture the normalized Swagger object graph consumed downstream.
+- Modifier bindings in [`Configuration`](Configuration/context.md) apply inclusion/exclusion, naming, and validation hints before
+  generation. `Program.cs` hydrates these via `ConfigurationLoader` and validates them with `SchemaValidator` prior to code
+  emission.
 
 ## Generation Pipeline
-- [`CodeGeneration`](CodeGeneration/context.md) contains classes that transform models into template-ready metadata and produce `GeneratedFile` instances.
-- [`Templates`](Templates/context.md) exposes the Handlebars templates used by the generator; see the folder context for format details.
+- [`CodeGeneration`](CodeGeneration/context.md) houses the transformation logic. `Program.cs` constructs `CodeGenerationOptions`
+  based on CLI switches, hands control to `CodeGenerator`, and handles file output/overwrite prompts.
+- [`Templates`](Templates/context.md) stores the Handlebars bindings. `Program.cs` supports overriding the template directory or
+  specifying a curated template list.
 
-## Samples and Assets
-- [`Samples`](Samples/context.md) offers example inputs and configuration seeds for quick testing.
+## Samples & Support Assets
+- [`Samples`](Samples/context.md) contains ready-to-run Swagger documents and modifier configs for demos.
+- Root-level configuration examples (`config_demo.cs`, YAML/JSON templates) show how to author modifier files programmatically.
 
-Tests validating these behaviors live under [../../tests/Asynkron.Jsome.Tests](../../tests/Asynkron.Jsome.Tests/context.md), providing durable-like regression guarantees.
+Validation and regression coverage reside in [../../tests/Asynkron.Jsome.Tests](../../tests/Asynkron.Jsome.Tests/context.md),
+mirroring Durable Functions' reliance on automated integration tests to protect orchestrator behavior.

--- a/src/context.md
+++ b/src/context.md
@@ -1,7 +1,19 @@
 # Source Tree Overview
 
-This directory contains the production code for the `Asynkron.Jsome` .NET tool. The layout intentionally mirrors the major phases of the generation pipeline:
+The `src` folder houses the production toolchain. `Asynkron.Jsome.sln` points to a single project,
+[`Asynkron.Jsome`](Asynkron.Jsome/context.md), which packs the CLI host, parsers, configuration system, code generator, templates,
+and sample inputs. Treat this folder as the Durable Functions "app"—the orchestrator, activities, and bindings all live below it.
 
-- [`Asynkron.Jsome`](Asynkron.Jsome/context.md) — CLI host, parsers, and all generation logic.
+Supporting build assets:
+- [`Asynkron.Jsome.sln`](../Asynkron.Jsome.sln) ties the CLI project to the tests under [`../tests`](../tests/context.md).
+- The project file [`Asynkron.Jsome.csproj`](Asynkron.Jsome/Asynkron.Jsome.csproj) defines dependencies
+  (System.CommandLine, Spectre.Console, Handlebars.Net, FluentValidation, Newtonsoft.Json, YamlDotNet) required by the
+  orchestration pipeline.
 
-While Azure Durable Functions organizes work into orchestrations, activity functions, and bindings, this source tree separates concerns into parsing, configuration, and templated emission. Each subdirectory's `context.md` explains how those responsibilities map onto Durable-like concepts (e.g., modifier rules behaving like orchestrator policies).
+Each subdirectory includes its own `context.md` with Durable-inspired metaphors for the responsibilities they cover:
+- [`Asynkron.Jsome`](Asynkron.Jsome/context.md) — entry point and feature pipeline.
+- [`Asynkron.Jsome/Templates`](Asynkron.Jsome/Templates/context.md) — template bindings.
+- [`Asynkron.Jsome/CodeGeneration`](Asynkron.Jsome/CodeGeneration/context.md) — activity-style transformation logic.
+- [`Asynkron.Jsome/Configuration`](Asynkron.Jsome/Configuration/context.md) — modifier bindings and validation.
+- [`Asynkron.Jsome/Models`](Asynkron.Jsome/Models/context.md) — shared schema state.
+- [`Asynkron.Jsome/Samples`](Asynkron.Jsome/Samples/context.md) — starter payloads and configs.

--- a/src/context.md
+++ b/src/context.md
@@ -2,7 +2,7 @@
 
 The `src` folder houses the production toolchain. `Asynkron.Jsome.sln` points to a single project,
 [`Asynkron.Jsome`](Asynkron.Jsome/context.md), which packs the CLI host, parsers, configuration system, code generator, templates,
-and sample inputs. Treat this folder as the Durable Functions "app"—the orchestrator, activities, and bindings all live below it.
+and sample inputs. Everything needed to run the generator end to end lives here.
 
 Supporting build assets:
 - [`Asynkron.Jsome.sln`](../Asynkron.Jsome.sln) ties the CLI project to the tests under [`../tests`](../tests/context.md).
@@ -10,7 +10,7 @@ Supporting build assets:
   (System.CommandLine, Spectre.Console, Handlebars.Net, FluentValidation, Newtonsoft.Json, YamlDotNet) required by the
   orchestration pipeline.
 
-Each subdirectory includes its own `context.md` with Durable-inspired metaphors for the responsibilities they cover:
+Each subdirectory includes its own `context.md` describing the responsibilities they cover:
 - [`Asynkron.Jsome`](Asynkron.Jsome/context.md) — entry point and feature pipeline.
 - [`Asynkron.Jsome/Templates`](Asynkron.Jsome/Templates/context.md) — template bindings.
 - [`Asynkron.Jsome/CodeGeneration`](Asynkron.Jsome/CodeGeneration/context.md) — activity-style transformation logic.

--- a/testdata/context.md
+++ b/testdata/context.md
@@ -1,6 +1,8 @@
 # Test Data
 
 Holds large or external sample inputs used during tests and demos.
-- `stripe-swagger.json` — Realistic Swagger 2.0 spec for validating parser resilience and generation performance.
+- `stripe-swagger.json` — Realistic Swagger 2.0 spec for validating parser resilience and generation performance. Referenced by
+  parser tests and manual experiments when you need a production-grade contract.
 
-Treat these artifacts like Durable Functions emulator payloads—feed them into the generator to observe behavior without touching production definitions.
+Treat these artifacts like Durable Functions emulator payloads—feed them into the generator to observe behavior without touching
+production definitions.

--- a/testdata/context.md
+++ b/testdata/context.md
@@ -4,5 +4,4 @@ Holds large or external sample inputs used during tests and demos.
 - `stripe-swagger.json` — Realistic Swagger 2.0 spec for validating parser resilience and generation performance. Referenced by
   parser tests and manual experiments when you need a production-grade contract.
 
-Treat these artifacts like Durable Functions emulator payloads—feed them into the generator to observe behavior without touching
-production definitions.
+Use these artifacts to observe generator behavior without touching production definitions.

--- a/tests/Asynkron.Jsome.Tests/context.md
+++ b/tests/Asynkron.Jsome.Tests/context.md
@@ -1,14 +1,32 @@
 # Asynkron.Jsome Test Project
 
-xUnit project validating parser correctness, configuration handling, template rendering, and language feature toggles. The structure resembles Azure Durable Functions' multi-phase testing: unit-level checks for orchestrator logic, integration tests for external definitions, and compilation validation to ensure generated code executes.
+xUnit project validating parser correctness, configuration handling, template rendering, and language feature toggles. The
+structure resembles Azure Durable Functions' multi-phase testing: unit-level checks for orchestrator logic, integration tests for
+external definitions, and compilation validation to ensure generated code executes.
 
-## Test Categories
-- **Code Generation Basics** (`CodeGenerationTests`, `CompilationValidationTests`) — Ensure DTOs/validators compile, required attributes appear, and generated code is syntactically valid.
-- **Configuration & Modifier Tests** (`ConfigurationTests`, `ModifierConfigurationIntegrationTests`, `SchemaValidatorTests`) — Verify `ModifierConfiguration` loading, rule application, and schema path validation. Mirrors Durable Function binding configuration tests.
-- **Template Extensibility** (`CustomTemplateTests`, `ProtoTemplateTests`, `SystemTextJsonTests`) — Guard template selection, proto output, and System.Text.Json enhancements.
-- **Modern C# Features** (`ModernCSharpFeaturesTests`) — Confirm nullable references, `required` keyword, and record generation toggles.
-- **Parser Validation** (`SwaggerParserTests`, `JsonSchemaParserTests`) — Validate error handling and parsing semantics for Swagger documents and JSON Schema directories.
-- **Domain-Specific Integrations** (`OcppV16ComplianceTests`, `OcppV16IntegrationTests`) — Exercise large schema sets from [../../schemas/ocppv16](../../schemas/ocppv16/context.md) to mimic Durable fan-out workloads over many definitions.
-- **Localization / Regression** (`LocaleIssueTest`) — Prevent culture-specific parsing regressions.
+## Test Categories & Files
+- **Code Generation Basics**
+  - `CodeGenerationTests` — DTO/validator emission, enum handling, namespace overrides, and template fallback scenarios.
+  - `CompilationValidationTests` — Runs Roslyn compilation against generated sources to guarantee syntactic validity.
+- **Configuration & Modifier Tests**
+  - `ConfigurationTests` — Round-trips YAML/JSON modifier files through `ConfigurationLoader`.
+  - `ModifierConfigurationIntegrationTests` — Applies property rules during generation to verify inclusion/exclusion behavior.
+  - `SchemaValidatorTests` — Ensures modifier paths map to actual schemas and emits Spectre.Console feedback just like CLI runs.
+- **Template Extensibility & Serialization**
+  - `CustomTemplateTests` — Points the generator at alternate template folders and checks partial template sets.
+  - `ProtoTemplateTests` — Exercises `.proto` frontmatter metadata and extension mapping.
+  - `SystemTextJsonTests` — Validates System.Text.Json attributes/validation when the corresponding CLI switch is enabled.
+- **Modern C# Features**
+  - `ModernCSharpFeaturesTests` — Confirms nullable reference type annotations, `required` keyword usage, and record generation.
+- **Parser Validation**
+  - `SwaggerParserTests` — Guards version checks, error messaging, and summary formatting.
+  - `JsonSchemaParserTests` — Covers directory ingestion, duplicate detection, `$ref` resolution, and malformed schema handling.
+- **Domain-Specific Integrations**
+  - `OcppV16IntegrationTests` — Generates code from [../../../schemas/ocppv16](../../../schemas/ocppv16/context.md) and verifies
+    file counts plus representative validators.
+  - `OcppV16ComplianceTests` — Focuses on enum/constant expectations for OCPP payloads.
+- **Localization / Regression**
+  - `LocaleIssueTest` — Prevents culture-specific parsing regressions (e.g., decimal separators).
 
-Global usings live in `GlobalUsings.cs`, and the project is defined by `Asynkron.Jsome.Tests.csproj`.
+Shared usings live in `GlobalUsings.cs`, and the project definition resides in `Asynkron.Jsome.Tests.csproj`. The suite depends on
+the CLI project at [../../src/Asynkron.Jsome](../../src/Asynkron.Jsome/context.md).

--- a/tests/Asynkron.Jsome.Tests/context.md
+++ b/tests/Asynkron.Jsome.Tests/context.md
@@ -1,8 +1,8 @@
 # Asynkron.Jsome Test Project
 
-xUnit project validating parser correctness, configuration handling, template rendering, and language feature toggles. The
-structure resembles Azure Durable Functions' multi-phase testing: unit-level checks for orchestrator logic, integration tests for
-external definitions, and compilation validation to ensure generated code executes.
+xUnit project validating parser correctness, configuration handling, template rendering, and language feature toggles. The suite
+covers unit-level checks for CLI orchestration, integration tests for external definitions, and compilation validation to ensure
+generated code executes.
 
 ## Test Categories & Files
 - **Code Generation Basics**

--- a/tests/context.md
+++ b/tests/context.md
@@ -1,6 +1,6 @@
 # Test Suite Overview
 
-The `tests` folder mirrors a Durable Functions validation environment: generated artifacts must compile, configuration must bind
+The `tests` folder exercises the generator end to end: generated artifacts must compile, configuration must bind
 correctly, and large schema workloads must succeed before shipping the CLI. All tests use xUnit and target .NET 8.
 
 - [`Asynkron.Jsome.Tests`](Asynkron.Jsome.Tests/context.md) — Primary test project covering code generation, configuration,

--- a/tests/context.md
+++ b/tests/context.md
@@ -1,5 +1,10 @@
 # Test Suite Overview
 
-The `tests` folder contains xUnit-based automated coverage for the generator. All projects target .NET 8 and mirror Azure Durable Functions' emphasis on regression safety—each suite verifies that declarative definitions expand into the expected runtime behavior.
+The `tests` folder mirrors a Durable Functions validation environment: generated artifacts must compile, configuration must bind
+correctly, and large schema workloads must succeed before shipping the CLI. All tests use xUnit and target .NET 8.
 
-- [`Asynkron.Jsome.Tests`](Asynkron.Jsome.Tests/context.md) — Main unit/integration test project.
+- [`Asynkron.Jsome.Tests`](Asynkron.Jsome.Tests/context.md) — Primary test project covering code generation, configuration,
+  parser behaviors, template customizations, proto output, modern C# toggles, and OCPP v1.6 integrations.
+
+The solution ties this project to [`src/Asynkron.Jsome`](../src/Asynkron.Jsome/context.md); workflows under
+[../.github/workflows](../.github/workflows/context.md) execute it on every commit.


### PR DESCRIPTION
## Summary
- refresh AGENTS guidance to emphasize the context.md knowledge graph
- expand context.md files across the repository with AI-oriented navigation notes and cross-links
- document schema, sample, and test directories so agents can trace relationships quickly

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68da1313ee188328b17a8d00a1b28ac3